### PR TITLE
fix: for persisting datastore selection for a workspace between IntelliJ sessions INTELLIJ-83

### DIFF
--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/EditorToolbarDecorator.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/EditorToolbarDecorator.kt
@@ -54,7 +54,7 @@ class EditorToolbarDecorator(
     // we override the stored project and toolbar everytime it is called
     override suspend fun execute(project: Project) {
         ApplicationManager.getApplication().runReadAction {
-            val toolbarSettings = useToolbarSettings()
+            val toolbarSettings = project.useToolbarSettings()
             val editorService = getEditorService(project)
             val dataSourceService = getDataSourceService(project)
 

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/services/MdbPluginDisposable.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/services/MdbPluginDisposable.kt
@@ -1,6 +1,8 @@
 package com.mongodb.jbplugin.editor.services
 
+import com.intellij.configurationStore.StoreUtil
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
@@ -33,6 +35,12 @@ class MdbPluginDisposable : Disposable {
      * Disposable interface that gets called when this service is being disposed
      */
     override fun dispose() {
+        // At the very least we would always want to persist our modified settings (ToolbarSettings, PluginSettings)
+        // when closing the project which is why we explicitly invoke StoreUtil.saveSettings to persist them to disk
+        ApplicationManager.getApplication().invokeLater {
+            StoreUtil.saveSettings(ApplicationManager.getApplication())
+        }
+
         val listeners = onDisposeListeners.toList()
         onDisposeListeners.clear()
         for (listener in listeners) {

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/services/MdbPluginDisposable.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/services/MdbPluginDisposable.kt
@@ -1,8 +1,6 @@
 package com.mongodb.jbplugin.editor.services
 
-import com.intellij.configurationStore.StoreUtil
 import com.intellij.openapi.Disposable
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
@@ -35,12 +33,6 @@ class MdbPluginDisposable : Disposable {
      * Disposable interface that gets called when this service is being disposed
      */
     override fun dispose() {
-        // At the very least we would always want to persist our modified settings (ToolbarSettings, PluginSettings)
-        // when closing the project which is why we explicitly invoke StoreUtil.saveSettings to persist them to disk
-        ApplicationManager.getApplication().invokeLater {
-            StoreUtil.saveSettings(ApplicationManager.getApplication())
-        }
-
         val listeners = onDisposeListeners.toList()
         onDisposeListeners.clear()
         for (listener in listeners) {

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/services/implementations/PersistentToolbarSettings.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/services/implementations/PersistentToolbarSettings.kt
@@ -5,15 +5,24 @@
 
 package com.mongodb.jbplugin.editor.services.implementations
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.*
+import com.intellij.openapi.project.Project
 import com.mongodb.jbplugin.editor.services.ToolbarSettings
 import java.io.Serializable
 
-@Service
+// Setting this service as a PROJECT service ensures that our state is saved per Project
+@Service(Service.Level.PROJECT)
 @State(
     name = "com.mongodb.jbplugin.editor.ToolbarSettings",
-    storages = [Storage(value = "MongodbToolbarSettings.xml")]
+    storages = [
+        Storage(
+            // File used to persist these settings per project
+            value = "MongodbToolbarSettings.xml",
+            // Setting roamingType to DEFAULT ensures that these settings are carried forward during IntelliJ updates
+            // as well
+            roamingType = RoamingType.DEFAULT
+        )
+    ]
 )
 private class ToolbarSettingsStateComponent :
     SimplePersistentStateComponent<PersistentToolbarSettings>(PersistentToolbarSettings())
@@ -30,7 +39,6 @@ private class PersistentToolbarSettings : BaseState(),
  *
  * @return
  */
-fun useToolbarSettings(): ToolbarSettings =
-    ApplicationManager.getApplication().getService(
-        ToolbarSettingsStateComponent::class.java
-    ).state
+fun Project.useToolbarSettings(): ToolbarSettings = getService(
+    ToolbarSettingsStateComponent::class.java
+).state


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER-IF-ANY>

  eg. fix(type-hint): infer type of a constant for type checking INTELLIJ-1111
-->

## Description
Came across this while testing INTELLIJ-83. We were persisting settings per application level and not per project. This PR fixes that and now we will be persisting settings per project level

<!--- Describe your changes in detail so reviewers have enough content on what this PR aims to achieve -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist

- [ ] New tests and/or benchmarks are included.
- [ ] Documentation is changed or added.
- [ ] Changelog is updated accordingly.
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement).

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->