### PR TITLE
chore: instead of running the whole pipeline again, only allow drafts when main is green already

### DIFF
--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -68,47 +68,10 @@ jobs:
             echo "If this version has already been release consider using a different one."
             exit 1
           fi
-      - name: Setup Docker (for Test Containers)
+      - name: Verify Checks in main
         run: |
-          sudo apt update -y
-          sudo apt install -y docker docker-compose
-      - name: Run Unit and Integration Tests
-        run: |
-          ./gradlew "unitTest" ":packages:jetbrains-plugin:test"
+          ./gradlew "mainStatus"
 
-      - name: Prepare License Key
-        env:
-          JB_TEST_KEY: ${{ secrets.JB_TEST_KEY }}
-        run: |
-          mkdir -p packages/jetbrains-plugin/build/idea-sandbox/config-uiTest
-          echo "$JB_TEST_KEY" | base64 -d > packages/jetbrains-plugin/build/idea-sandbox/config-uiTest/idea.key
-      - name: Start UI Test Environment
-        run: |
-          export DISPLAY=:99.0
-          Xvfb -ac :99 -screen 0 1920x1080x24 &
-          sleep 10
-          mkdir -p packages/jetbrains-plugin/build/reports
-          ./gradlew :packages:jetbrains-plugin:runIdeForUiTests > packages/jetbrains-plugin/build/reports/idea.log &
-          IDEA_PID=$!
-          echo $IDEA_PID > idea.pid
-      - name: Wait for IDE to start
-        uses: jtalk/url-health-check-action@v3
-        with:
-          url: "http://127.0.0.1:8082"
-          max-attempts: 15
-          retry-delay: 30s
-      - name: Run UI Tests
-        uses: nick-fields/retry@v3
-        env:
-          DISPLAY: ":99.0"
-        with:
-          timeout_minutes: 30
-          max_attempts: 3
-          command: ./gradlew --quiet --console=plain :packages:jetbrains-plugin:uiTest
-      - name: Stop IDEA
-        run: |
-          IDEA_PID=$(cat idea.pid)
-          kill -9 $IDEA_PID
       - name: Patch Plugin XML
         run: |
           ./gradlew ":packages:jetbrains-plugin:patchPluginXml"


### PR DESCRIPTION
<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER-IF-ANY>

  eg. fix(type-hint): infer type of a constant for type checking INTELLIJ-1111
-->

## Description

<!--- Describe your changes in detail so reviewers have enough content on what this PR aims to achieve -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist

- [ ] New tests and/or benchmarks are included.
- [ ] Documentation is changed or added.
- [ ] Changelog is updated accordingly.
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement).

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->