### PR TITLE
Poc/di

### DIFF
--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/ActivatePluginPostStartupActivity.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/ActivatePluginPostStartupActivity.kt
@@ -9,15 +9,15 @@ import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.StartupActivity
 import com.mongodb.jbplugin.i18n.TelemetryMessages
+import com.mongodb.jbplugin.meta.injecting
 import com.mongodb.jbplugin.observability.probe.PluginActivatedProbe
 import com.mongodb.jbplugin.settings.PluginSettingsConfigurable
-import com.mongodb.jbplugin.settings.useSettings
+import com.mongodb.jbplugin.settings.pluginSetting
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -54,13 +54,14 @@ class ActivatePluginPostStartupActivity(
 ) : StartupActivity, DumbAware {
     override fun runActivity(project: Project) {
         cs.launch {
-            val pluginActivated = ApplicationManager.getApplication().getService(
-                PluginActivatedProbe::class.java
-            )
+            val pluginActivated by injecting<PluginActivatedProbe>()
             pluginActivated.pluginActivated()
 
-            val settings = useSettings()
-            if (!settings.hasTelemetryOptOutputNotificationBeenShown) {
+            var firstTimeTelemetry by pluginSetting<Boolean> {
+                ::hasTelemetryOptOutputNotificationBeenShown
+            }
+
+            if (!firstTimeTelemetry) {
                 NotificationGroupManager.getInstance()
                     .getNotificationGroup("com.mongodb.jbplugin.notifications.Telemetry")
                     .createNotification(
@@ -73,7 +74,7 @@ class ActivatePluginPostStartupActivity(
                     .addAction(OpenMongoDbPluginSettingsAction())
                     .notify(project)
 
-                settings.hasTelemetryOptOutputNotificationBeenShown = true
+                firstTimeTelemetry = true
             }
         }
     }

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/ActivatePluginPostStartupActivity.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/ActivatePluginPostStartupActivity.kt
@@ -14,7 +14,7 @@ import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.StartupActivity
 import com.mongodb.jbplugin.i18n.TelemetryMessages
-import com.mongodb.jbplugin.meta.injecting
+import com.mongodb.jbplugin.meta.service
 import com.mongodb.jbplugin.observability.probe.PluginActivatedProbe
 import com.mongodb.jbplugin.settings.PluginSettingsConfigurable
 import com.mongodb.jbplugin.settings.pluginSetting
@@ -54,7 +54,7 @@ class ActivatePluginPostStartupActivity(
 ) : StartupActivity, DumbAware {
     override fun runActivity(project: Project) {
         cs.launch {
-            val pluginActivated by injecting<PluginActivatedProbe>()
+            val pluginActivated by service<PluginActivatedProbe>()
             pluginActivated.pluginActivated()
 
             var firstTimeTelemetry by pluginSetting<Boolean> {

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/autocomplete/MongoDbCompletionContributor.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/autocomplete/MongoDbCompletionContributor.kt
@@ -9,7 +9,6 @@ import com.intellij.codeInsight.lookup.AutoCompletionPolicy
 import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.database.dataSource.localDataSource
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.patterns.ElementPattern
 import com.intellij.patterns.ElementPatternCondition
@@ -35,6 +34,7 @@ import com.mongodb.jbplugin.editor.dataSource
 import com.mongodb.jbplugin.editor.database
 import com.mongodb.jbplugin.editor.dialect
 import com.mongodb.jbplugin.i18n.Icons
+import com.mongodb.jbplugin.meta.injecting
 import com.mongodb.jbplugin.mql.Namespace
 import com.mongodb.jbplugin.mql.components.HasCollectionReference
 import com.mongodb.jbplugin.observability.probe.AutocompleteSuggestionAcceptedProbe
@@ -65,10 +65,7 @@ internal object Database {
             result: CompletionResultSet,
         ) {
             val dataSource = parameters.originalFile.dataSource!!
-            val readModelProvider =
-                parameters.originalFile.project.getService(
-                    DataGripBasedReadModelProvider::class.java,
-                )
+            val readModelProvider by parameters.originalFile.project.injecting<DataGripBasedReadModelProvider>()
 
             val completions =
                 Autocompletion.autocompleteDatabases(
@@ -100,10 +97,7 @@ internal object Collection {
 
             database ?: return
 
-            val readModelProvider =
-                parameters.originalFile.project.getService(
-                    DataGripBasedReadModelProvider::class.java,
-                )
+            val readModelProvider by parameters.originalFile.project.injecting<DataGripBasedReadModelProvider>()
 
             val completions =
                 Autocompletion.autocompleteCollections(
@@ -137,10 +131,8 @@ internal object Field {
             if (database == null || collection == null) {
                 return
             }
-            val readModelProvider =
-                parameters.originalFile.project.getService(
-                    DataGripBasedReadModelProvider::class.java,
-                )
+
+            val readModelProvider by parameters.originalFile.project.injecting<DataGripBasedReadModelProvider>()
 
             val completions =
                 Autocompletion.autocompleteFields(
@@ -196,10 +188,7 @@ private object MongoDbElementPatterns {
             LookupElementBuilder
                 .create(entry)
                 .withInsertHandler { _, _ ->
-                    val application = ApplicationManager.getApplication()
-                    val probe = application.getService(
-                        AutocompleteSuggestionAcceptedProbe::class.java
-                    )
+                    val probe by injecting<AutocompleteSuggestionAcceptedProbe>()
 
                     when (this.type) {
                         AutocompletionEntry.AutocompletionEntryType.DATABASE ->

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/autocomplete/MongoDbCompletionContributor.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/autocomplete/MongoDbCompletionContributor.kt
@@ -34,7 +34,7 @@ import com.mongodb.jbplugin.editor.dataSource
 import com.mongodb.jbplugin.editor.database
 import com.mongodb.jbplugin.editor.dialect
 import com.mongodb.jbplugin.i18n.Icons
-import com.mongodb.jbplugin.meta.injecting
+import com.mongodb.jbplugin.meta.service
 import com.mongodb.jbplugin.mql.Namespace
 import com.mongodb.jbplugin.mql.components.HasCollectionReference
 import com.mongodb.jbplugin.observability.probe.AutocompleteSuggestionAcceptedProbe
@@ -65,7 +65,7 @@ internal object Database {
             result: CompletionResultSet,
         ) {
             val dataSource = parameters.originalFile.dataSource!!
-            val readModelProvider by parameters.originalFile.project.injecting<DataGripBasedReadModelProvider>()
+            val readModelProvider by parameters.originalFile.project.service<DataGripBasedReadModelProvider>()
 
             val completions =
                 Autocompletion.autocompleteDatabases(
@@ -97,7 +97,7 @@ internal object Collection {
 
             database ?: return
 
-            val readModelProvider by parameters.originalFile.project.injecting<DataGripBasedReadModelProvider>()
+            val readModelProvider by parameters.originalFile.project.service<DataGripBasedReadModelProvider>()
 
             val completions =
                 Autocompletion.autocompleteCollections(
@@ -132,7 +132,7 @@ internal object Field {
                 return
             }
 
-            val readModelProvider by parameters.originalFile.project.injecting<DataGripBasedReadModelProvider>()
+            val readModelProvider by parameters.originalFile.project.service<DataGripBasedReadModelProvider>()
 
             val completions =
                 Autocompletion.autocompleteFields(
@@ -188,7 +188,7 @@ private object MongoDbElementPatterns {
             LookupElementBuilder
                 .create(entry)
                 .withInsertHandler { _, _ ->
-                    val probe by injecting<AutocompleteSuggestionAcceptedProbe>()
+                    val probe by service<AutocompleteSuggestionAcceptedProbe>()
 
                     when (this.type) {
                         AutocompletionEntry.AutocompletionEntryType.DATABASE ->

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/codeActions/AbstractMongoDbCodeActionBridge.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/codeActions/AbstractMongoDbCodeActionBridge.kt
@@ -10,6 +10,7 @@ import com.intellij.psi.util.*
 import com.mongodb.jbplugin.editor.CachedQueryService
 import com.mongodb.jbplugin.editor.dataSource
 import com.mongodb.jbplugin.editor.dialect
+import com.mongodb.jbplugin.meta.injecting
 import com.mongodb.jbplugin.mql.Node
 import kotlinx.coroutines.CoroutineScope
 
@@ -54,7 +55,8 @@ abstract class AbstractMongoDbCodeActionBridge(
             val dataSource = fileInExpression.dataSource
             val dialect = expression.containingFile.dialect ?: return@runReadAction null
 
-            val queryService = expression.project.getService(CachedQueryService::class.java)
+            val queryService by expression.project.injecting<CachedQueryService>()
+
             queryService.queryAt(expression)?.let { query ->
                 fileInExpression.virtualFile?.let {
                     codeAction.visitMongoDbQuery(

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/codeActions/AbstractMongoDbCodeActionBridge.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/codeActions/AbstractMongoDbCodeActionBridge.kt
@@ -10,7 +10,7 @@ import com.intellij.psi.util.*
 import com.mongodb.jbplugin.editor.CachedQueryService
 import com.mongodb.jbplugin.editor.dataSource
 import com.mongodb.jbplugin.editor.dialect
-import com.mongodb.jbplugin.meta.injecting
+import com.mongodb.jbplugin.meta.service
 import com.mongodb.jbplugin.mql.Node
 import kotlinx.coroutines.CoroutineScope
 
@@ -55,7 +55,7 @@ abstract class AbstractMongoDbCodeActionBridge(
             val dataSource = fileInExpression.dataSource
             val dialect = expression.containingFile.dialect ?: return@runReadAction null
 
-            val queryService by expression.project.injecting<CachedQueryService>()
+            val queryService by expression.project.service<CachedQueryService>()
 
             queryService.queryAt(expression)?.let { query ->
                 fileInExpression.virtualFile?.let {

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/CachedQueryService.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/CachedQueryService.kt
@@ -13,6 +13,7 @@ import com.intellij.psi.util.PsiTreeUtil
 import com.mongodb.jbplugin.accessadapter.datagrip.DataGripBasedReadModelProvider
 import com.mongodb.jbplugin.accessadapter.datagrip.adapter.isConnected
 import com.mongodb.jbplugin.accessadapter.slice.BuildInfo
+import com.mongodb.jbplugin.meta.injecting
 import com.mongodb.jbplugin.mql.Node
 import com.mongodb.jbplugin.mql.components.HasTargetCluster
 import io.github.z4kn4fein.semver.Version
@@ -70,9 +71,7 @@ class CachedQueryService(
 
         return runCatching {
             if (dataSource != null && dataSource.isConnected()) {
-                val readModel = query.source.project.getService(
-                    DataGripBasedReadModelProvider::class.java
-                )
+                val readModel by query.source.project.injecting<DataGripBasedReadModelProvider>()
                 val buildInfo = readModel.slice(dataSource, BuildInfo.Slice)
 
                 queryWithDb.withTargetCluster(

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/CachedQueryService.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/CachedQueryService.kt
@@ -13,7 +13,7 @@ import com.intellij.psi.util.PsiTreeUtil
 import com.mongodb.jbplugin.accessadapter.datagrip.DataGripBasedReadModelProvider
 import com.mongodb.jbplugin.accessadapter.datagrip.adapter.isConnected
 import com.mongodb.jbplugin.accessadapter.slice.BuildInfo
-import com.mongodb.jbplugin.meta.injecting
+import com.mongodb.jbplugin.meta.service
 import com.mongodb.jbplugin.mql.Node
 import com.mongodb.jbplugin.mql.components.HasTargetCluster
 import io.github.z4kn4fein.semver.Version
@@ -71,7 +71,7 @@ class CachedQueryService(
 
         return runCatching {
             if (dataSource != null && dataSource.isConnected()) {
-                val readModel by query.source.project.injecting<DataGripBasedReadModelProvider>()
+                val readModel by query.source.project.service<DataGripBasedReadModelProvider>()
                 val buildInfo = readModel.slice(dataSource, BuildInfo.Slice)
 
                 queryWithDb.withTargetCluster(

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/services/implementations/MdbDataSourceService.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/services/implementations/MdbDataSourceService.kt
@@ -16,7 +16,7 @@ import com.mongodb.jbplugin.accessadapter.slice.ListDatabases
 import com.mongodb.jbplugin.editor.services.ConnectionState
 import com.mongodb.jbplugin.editor.services.DataSourceService
 import com.mongodb.jbplugin.editor.services.DatabasesLoadingState
-import com.mongodb.jbplugin.meta.injecting
+import com.mongodb.jbplugin.meta.service
 import kotlinx.coroutines.CoroutineScope
 
 private val log = logger<MdbDataSourceService>()
@@ -44,7 +44,7 @@ class MdbDataSourceService(
         coroutineScope.launchChildBackground {
             onLoadingStateChanged(DatabasesLoadingState.Started)
             try {
-                val readModel by project.injecting<DataGripBasedReadModelProvider>()
+                val readModel by project.service<DataGripBasedReadModelProvider>()
                 val databases = readModel.slice(dataSource, ListDatabases.Slice)
                 onLoadingStateChanged(
                     DatabasesLoadingState.Finished(databases.databases.map { it.name })

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/services/implementations/MdbDataSourceService.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/editor/services/implementations/MdbDataSourceService.kt
@@ -16,6 +16,7 @@ import com.mongodb.jbplugin.accessadapter.slice.ListDatabases
 import com.mongodb.jbplugin.editor.services.ConnectionState
 import com.mongodb.jbplugin.editor.services.DataSourceService
 import com.mongodb.jbplugin.editor.services.DatabasesLoadingState
+import com.mongodb.jbplugin.meta.injecting
 import kotlinx.coroutines.CoroutineScope
 
 private val log = logger<MdbDataSourceService>()
@@ -43,7 +44,7 @@ class MdbDataSourceService(
         coroutineScope.launchChildBackground {
             onLoadingStateChanged(DatabasesLoadingState.Started)
             try {
-                val readModel = project.getService(DataGripBasedReadModelProvider::class.java)
+                val readModel by project.injecting<DataGripBasedReadModelProvider>()
                 val databases = readModel.slice(dataSource, ListDatabases.Slice)
                 onLoadingStateChanged(
                     DatabasesLoadingState.Finished(databases.databases.map { it.name })

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/inspections/AbstractMongoDbInspectionBridge.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/inspections/AbstractMongoDbInspectionBridge.kt
@@ -10,6 +10,7 @@ import com.intellij.psi.util.PsiTreeUtil
 import com.mongodb.jbplugin.editor.CachedQueryService
 import com.mongodb.jbplugin.editor.dataSource
 import com.mongodb.jbplugin.editor.dialect
+import com.mongodb.jbplugin.meta.injecting
 import kotlinx.coroutines.CoroutineScope
 
 /**
@@ -51,7 +52,7 @@ abstract class AbstractMongoDbInspectionBridge(
                     val dataSource = fileInExpression.dataSource
                     val dialect = expression.containingFile.dialect ?: return@runReadAction
 
-                    val queryService = expression.project.getService(CachedQueryService::class.java)
+                    val queryService by expression.project.injecting<CachedQueryService>()
                     queryService.queryAt(expression)?.let { query ->
                         fileInExpression.virtualFile?.let {
                             inspection.visitMongoDbQuery(

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/inspections/AbstractMongoDbInspectionBridge.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/inspections/AbstractMongoDbInspectionBridge.kt
@@ -10,7 +10,7 @@ import com.intellij.psi.util.PsiTreeUtil
 import com.mongodb.jbplugin.editor.CachedQueryService
 import com.mongodb.jbplugin.editor.dataSource
 import com.mongodb.jbplugin.editor.dialect
-import com.mongodb.jbplugin.meta.injecting
+import com.mongodb.jbplugin.meta.service
 import kotlinx.coroutines.CoroutineScope
 
 /**
@@ -52,7 +52,7 @@ abstract class AbstractMongoDbInspectionBridge(
                     val dataSource = fileInExpression.dataSource
                     val dialect = expression.containingFile.dialect ?: return@runReadAction
 
-                    val queryService by expression.project.injecting<CachedQueryService>()
+                    val queryService by expression.project.service<CachedQueryService>()
                     queryService.queryAt(expression)?.let { query ->
                         fileInExpression.virtualFile?.let {
                             inspection.visitMongoDbQuery(

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/inspections/impl/FieldCheckInspectionBridge.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/inspections/impl/FieldCheckInspectionBridge.kt
@@ -18,6 +18,7 @@ import com.mongodb.jbplugin.inspections.MongoDbInspection
 import com.mongodb.jbplugin.inspections.quickfixes.OpenConnectionChooserQuickFix
 import com.mongodb.jbplugin.linting.FieldCheckWarning
 import com.mongodb.jbplugin.linting.FieldCheckingLinter
+import com.mongodb.jbplugin.meta.injecting
 import com.mongodb.jbplugin.mql.Node
 import com.mongodb.jbplugin.mql.components.HasCollectionReference
 import kotlinx.coroutines.CoroutineScope
@@ -52,9 +53,7 @@ internal object FieldCheckLinterInspection : MongoDbInspection {
             return registerNoDatabaseSelectedProblem(coroutineScope, problems, query.source)
         }
 
-        val readModelProvider = query.source.project.getService(
-            DataGripBasedReadModelProvider::class.java
-        )
+        val readModelProvider by query.source.project.injecting<DataGripBasedReadModelProvider>()
 
         val result =
             FieldCheckingLinter.lintQuery(

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/inspections/impl/FieldCheckInspectionBridge.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/inspections/impl/FieldCheckInspectionBridge.kt
@@ -18,7 +18,7 @@ import com.mongodb.jbplugin.inspections.MongoDbInspection
 import com.mongodb.jbplugin.inspections.quickfixes.OpenConnectionChooserQuickFix
 import com.mongodb.jbplugin.linting.FieldCheckWarning
 import com.mongodb.jbplugin.linting.FieldCheckingLinter
-import com.mongodb.jbplugin.meta.injecting
+import com.mongodb.jbplugin.meta.service
 import com.mongodb.jbplugin.mql.Node
 import com.mongodb.jbplugin.mql.components.HasCollectionReference
 import kotlinx.coroutines.CoroutineScope
@@ -53,7 +53,7 @@ internal object FieldCheckLinterInspection : MongoDbInspection {
             return registerNoDatabaseSelectedProblem(coroutineScope, problems, query.source)
         }
 
-        val readModelProvider by query.source.project.injecting<DataGripBasedReadModelProvider>()
+        val readModelProvider by query.source.project.service<DataGripBasedReadModelProvider>()
 
         val result =
             FieldCheckingLinter.lintQuery(

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/inspections/impl/IndexCheckInspectionBridge.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/inspections/impl/IndexCheckInspectionBridge.kt
@@ -19,6 +19,7 @@ import com.mongodb.jbplugin.inspections.MongoDbInspection
 import com.mongodb.jbplugin.inspections.quickfixes.OpenDataSourceConsoleAppendingCode
 import com.mongodb.jbplugin.linting.IndexCheckWarning
 import com.mongodb.jbplugin.linting.IndexCheckingLinter
+import com.mongodb.jbplugin.meta.injecting
 import com.mongodb.jbplugin.mql.Node
 import kotlinx.coroutines.CoroutineScope
 
@@ -48,10 +49,7 @@ internal object IndexCheckLinterInspection : MongoDbInspection {
             return
         }
 
-        val readModelProvider = query.source.project.getService(
-            DataGripBasedReadModelProvider::class.java
-        )
-
+        val readModelProvider by query.source.project.injecting<DataGripBasedReadModelProvider>()
         val result =
             IndexCheckingLinter.lintQuery(
                 dataSource,

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/inspections/impl/IndexCheckInspectionBridge.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/inspections/impl/IndexCheckInspectionBridge.kt
@@ -19,7 +19,7 @@ import com.mongodb.jbplugin.inspections.MongoDbInspection
 import com.mongodb.jbplugin.inspections.quickfixes.OpenDataSourceConsoleAppendingCode
 import com.mongodb.jbplugin.linting.IndexCheckWarning
 import com.mongodb.jbplugin.linting.IndexCheckingLinter
-import com.mongodb.jbplugin.meta.injecting
+import com.mongodb.jbplugin.meta.service
 import com.mongodb.jbplugin.mql.Node
 import kotlinx.coroutines.CoroutineScope
 
@@ -49,7 +49,7 @@ internal object IndexCheckLinterInspection : MongoDbInspection {
             return
         }
 
-        val readModelProvider by query.source.project.injecting<DataGripBasedReadModelProvider>()
+        val readModelProvider by query.source.project.service<DataGripBasedReadModelProvider>()
         val result =
             IndexCheckingLinter.lintQuery(
                 dataSource,

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/inspections/impl/NamespaceCheckInspectionBridge.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/inspections/impl/NamespaceCheckInspectionBridge.kt
@@ -18,7 +18,7 @@ import com.mongodb.jbplugin.inspections.MongoDbInspection
 import com.mongodb.jbplugin.inspections.quickfixes.OpenConnectionChooserQuickFix
 import com.mongodb.jbplugin.linting.NamespaceCheckWarning
 import com.mongodb.jbplugin.linting.NamespaceCheckingLinter
-import com.mongodb.jbplugin.meta.injecting
+import com.mongodb.jbplugin.meta.service
 import com.mongodb.jbplugin.mql.Node
 import kotlinx.coroutines.CoroutineScope
 
@@ -48,7 +48,7 @@ internal object NamespaceCheckingLinterInspection : MongoDbInspection {
             return
         }
 
-        val readModelProvider by query.source.project.injecting<DataGripBasedReadModelProvider>()
+        val readModelProvider by query.source.project.service<DataGripBasedReadModelProvider>()
         val result =
             NamespaceCheckingLinter.lintQuery(
                 dataSource,

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/inspections/impl/NamespaceCheckInspectionBridge.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/inspections/impl/NamespaceCheckInspectionBridge.kt
@@ -18,6 +18,7 @@ import com.mongodb.jbplugin.inspections.MongoDbInspection
 import com.mongodb.jbplugin.inspections.quickfixes.OpenConnectionChooserQuickFix
 import com.mongodb.jbplugin.linting.NamespaceCheckWarning
 import com.mongodb.jbplugin.linting.NamespaceCheckingLinter
+import com.mongodb.jbplugin.meta.injecting
 import com.mongodb.jbplugin.mql.Node
 import kotlinx.coroutines.CoroutineScope
 
@@ -47,10 +48,7 @@ internal object NamespaceCheckingLinterInspection : MongoDbInspection {
             return
         }
 
-        val readModelProvider = query.source.project.getService(
-            DataGripBasedReadModelProvider::class.java
-        )
-
+        val readModelProvider by query.source.project.injecting<DataGripBasedReadModelProvider>()
         val result =
             NamespaceCheckingLinter.lintQuery(
                 dataSource,

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/meta/BuildInformation.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/meta/BuildInformation.kt
@@ -16,6 +16,6 @@ object BuildInformation {
     private val properties: Properties = Properties().also {
         it.load(BuildInformation::class.java.getResourceAsStream("/build.properties"))
     }
-    val pluginVersion = properties["pluginVersion"]!!.toString()
-    val segmentApiKey = properties["segmentApiKey"]!!.toString()
+    val pluginVersion: String by properties
+    val segmentApiKey: String by properties
 }

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/meta/DependencyInjection.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/meta/DependencyInjection.kt
@@ -11,10 +11,10 @@ class DependencyInjection<out T>(private val cm: ComponentManager, private val j
     }
 }
 
-inline fun <reified T> injecting(): DependencyInjection<T> {
+inline fun <reified T> service(): DependencyInjection<T> {
     return DependencyInjection(ApplicationManager.getApplication(), T::class.java)
 }
 
-inline fun <reified T> Project.injecting(): DependencyInjection<T> {
+inline fun <reified T> Project.service(): DependencyInjection<T> {
     return DependencyInjection(this, T::class.java)
 }

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/meta/DependencyInjection.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/meta/DependencyInjection.kt
@@ -1,8 +1,17 @@
 package com.mongodb.jbplugin.meta
 
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.ComponentManager
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.rd.util.launchChildBackground
+import com.intellij.openapi.util.Disposer
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlin.reflect.KProperty
 
 class DependencyInjection<out T>(private val cm: ComponentManager, private val javaClass: Class<T>) {
@@ -11,10 +20,91 @@ class DependencyInjection<out T>(private val cm: ComponentManager, private val j
     }
 }
 
+/**
+ * Injects an application service into a val.
+ *
+ * ```kt
+ *  val pluginActivated by service<PluginActivatedProbe>()
+ * ```
+ */
 inline fun <reified T> service(): DependencyInjection<T> {
     return DependencyInjection(ApplicationManager.getApplication(), T::class.java)
 }
 
+/**
+ * Injects a project-wide service into a val.
+ *
+ * ```kt
+ * val readModelProvider by project.service<DataGripBasedReadModelProvider>()
+ * ```
+ */
+
 inline fun <reified T> Project.service(): DependencyInjection<T> {
     return DependencyInjection(this, T::class.java)
 }
+
+// We probably don't want to use a lot of threads for this. First because updating the state should
+// be straightforward (to avoid lag) and because state updates should be sequential.
+private val asyncStatusRefreshScope = Dispatchers.IO.limitedParallelism(1)
+
+class AsyncState<E : Any, T : Any>(
+    parent: Disposable,
+    private val sharedFlow: SharedFlow<E>,
+    private val accessor: E.() -> T
+) : Disposable {
+    private lateinit var state: T
+    private val scope: CoroutineScope = CoroutineScope(asyncStatusRefreshScope)
+
+    init {
+        scope.launchChildBackground {
+            sharedFlow.collectLatest {
+                state = it.accessor()
+            }
+        }
+
+        Disposer.register(parent, this)
+    }
+
+    operator fun getValue(
+        thisRef: Any?,
+        property: KProperty<*>
+    ): T {
+        return state
+    }
+
+    override fun dispose() {
+        scope.cancel()
+    }
+}
+
+/**
+ * We will need to synchronise the state from a SharedFlow when we are doing work in the background.
+ * However, we want to make it seamless, and we don't want to by coupled to the shared flow syntax.
+ * This delegate should synchronise the variable with the latest event of the SharedFlow. For example:
+ *
+ * ```kt
+ * class EventNumber(val numberInEvent: Int)
+ * val sharedFlow: SharedFlow<EventNumber>
+ * val lastNumber by sharedFlow.latest { numberInEvent }
+ * ```
+ *
+ * It can also be used to compute an expression across properties in an event:
+ * ```kt
+ * class EventNumber(val numberInEvent: Int, val otherNumber: Int)
+ * val sharedFlow: SharedFlow<EventNumber>
+ * val computedNumber by sharedFlow.latest { numberInEvent * otherNumber }
+ * ```
+ *
+ * It will be closed when the current project is closed. If no projects are available,
+ * it will be closed when the IDE is closed.
+ */
+fun <E : Any, T : Any> SharedFlow<E>.latest(
+    parent: Disposable = ProjectManager.getInstance().openProjects.firstOrNull()
+        ?: ApplicationManager.getApplication(),
+    prop: E.() -> T
+): AsyncState<E, T> =
+    AsyncState(
+        parent,
+        this,
+        prop
+    )

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/meta/DependencyInjection.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/meta/DependencyInjection.kt
@@ -1,0 +1,20 @@
+package com.mongodb.jbplugin.meta
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.ComponentManager
+import com.intellij.openapi.project.Project
+import kotlin.reflect.KProperty
+
+class DependencyInjection<out T>(private val cm: ComponentManager, private val javaClass: Class<T>) {
+    operator fun getValue(thisRef: Any?, property: KProperty<*>): T {
+        return cm.getService<T>(javaClass)
+    }
+}
+
+inline fun <reified T> injecting(): DependencyInjection<T> {
+    return DependencyInjection(ApplicationManager.getApplication(), T::class.java)
+}
+
+inline fun <reified T> Project.injecting(): DependencyInjection<T> {
+    return DependencyInjection(this, T::class.java)
+}

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/observability/LogMessage.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/observability/LogMessage.kt
@@ -16,6 +16,7 @@ import com.intellij.ide.PowerSaveMode
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.mongodb.jbplugin.meta.BuildInformation
+import com.mongodb.jbplugin.meta.injecting
 
 /**
  * @param gson
@@ -62,10 +63,7 @@ class LogMessage {
     private val gson = GsonBuilder().generateNonExecutableJson().disableJdkUnsafe().create()
 
     fun message(key: String): LogMessageBuilder {
-        val runtimeInformationService =
-            ApplicationManager.getApplication().getService(
-                RuntimeInformationService::class.java,
-            )
+        val runtimeInformationService by injecting<RuntimeInformationService>()
         val runtimeInformation = runtimeInformationService.get()
 
         return LogMessageBuilder(gson, key)

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/observability/LogMessage.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/observability/LogMessage.kt
@@ -16,7 +16,7 @@ import com.intellij.ide.PowerSaveMode
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.mongodb.jbplugin.meta.BuildInformation
-import com.mongodb.jbplugin.meta.injecting
+import com.mongodb.jbplugin.meta.service
 
 /**
  * @param gson
@@ -63,7 +63,7 @@ class LogMessage {
     private val gson = GsonBuilder().generateNonExecutableJson().disableJdkUnsafe().create()
 
     fun message(key: String): LogMessageBuilder {
-        val runtimeInformationService by injecting<RuntimeInformationService>()
+        val runtimeInformationService by service<RuntimeInformationService>()
         val runtimeInformation = runtimeInformationService.get()
 
         return LogMessageBuilder(gson, key)

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/observability/RuntimeInformationService.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/observability/RuntimeInformationService.kt
@@ -40,15 +40,34 @@ data class RuntimeInformation(
  */
 @Service
 class RuntimeInformationService {
-    private val userId = getOrDefault("<userId>") { PermanentInstallationID.get() }
-    private val osName = getOrDefault("<osName>") { SystemInfo.getOsNameAndVersion() }
-    private val arch = getOrDefault("<arch>") { SystemInfo.OS_ARCH }
-    private val jvmVendor = getOrDefault("<jvmVendor>") { SystemInfo.JAVA_VENDOR }
-    private val jvmVersion = getOrDefault("<jvmVersion>") { SystemInfo.JAVA_VERSION }
-    private val buildVersion =
+    private val userId by lazy {
+        getOrDefault("<userId>") { PermanentInstallationID.get() }
+    }
+
+    private val osName by lazy {
+        getOrDefault("<osName>") { SystemInfo.getOsNameAndVersion() }
+    }
+
+    private val arch by lazy {
+        getOrDefault("<arch>") { SystemInfo.OS_ARCH }
+    }
+
+    private val jvmVendor by lazy {
+        getOrDefault("<jvmVendor>") { SystemInfo.JAVA_VENDOR }
+    }
+
+    private val jvmVersion by lazy {
+        getOrDefault("<jvmVersion>") { SystemInfo.JAVA_VERSION }
+    }
+
+    private val buildVersion by lazy {
         getOrDefault("<fullVersion>") { ApplicationInfo.getInstance().fullVersion }
-    private val applicationName = getOrDefault("<fullApplicationName>") {
-        ApplicationInfo.getInstance().fullApplicationName
+    }
+
+    private val applicationName by lazy {
+        getOrDefault("<fullApplicationName>") {
+            ApplicationInfo.getInstance().fullApplicationName
+        }
     }
 
     fun get(): RuntimeInformation = RuntimeInformation(

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/observability/TelemetryService.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/observability/TelemetryService.kt
@@ -6,7 +6,8 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.diagnostic.logger
 import com.mongodb.jbplugin.meta.BuildInformation
-import com.mongodb.jbplugin.settings.useSettings
+import com.mongodb.jbplugin.meta.injecting
+import com.mongodb.jbplugin.settings.pluginSetting
 import com.segment.analytics.Analytics
 import com.segment.analytics.messages.TrackMessage
 
@@ -34,14 +35,13 @@ internal class TelemetryService : AppLifecycleListener {
     }
 
     fun sendEvent(event: TelemetryEvent) {
-        if (!useSettings().isTelemetryEnabled) {
+        val isTelemetryEnabled by pluginSetting { ::isTelemetryEnabled }
+
+        if (!isTelemetryEnabled) {
             return
         }
 
-        val runtimeInformationService =
-            ApplicationManager.getApplication().getService(
-                RuntimeInformationService::class.java,
-            )
+        val runtimeInformationService by injecting<RuntimeInformationService>()
         val runtimeInfo = runtimeInformationService.get()
 
         val message = TrackMessage.builder(event.name)
@@ -58,7 +58,7 @@ internal class TelemetryService : AppLifecycleListener {
     }
 
     override fun appWillBeClosed(isRestart: Boolean) {
-        val telemetryEnabled = useSettings().isTelemetryEnabled
+        val telemetryEnabled by pluginSetting { ::isTelemetryEnabled }
 
         logger.info(
             useLogMessage("Shutting down Segment analytics because the IDE is closing.")

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/observability/TelemetryService.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/observability/TelemetryService.kt
@@ -6,7 +6,7 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.diagnostic.logger
 import com.mongodb.jbplugin.meta.BuildInformation
-import com.mongodb.jbplugin.meta.injecting
+import com.mongodb.jbplugin.meta.service
 import com.mongodb.jbplugin.settings.pluginSetting
 import com.segment.analytics.Analytics
 import com.segment.analytics.messages.TrackMessage
@@ -41,7 +41,7 @@ internal class TelemetryService : AppLifecycleListener {
             return
         }
 
-        val runtimeInformationService by injecting<RuntimeInformationService>()
+        val runtimeInformationService by service<RuntimeInformationService>()
         val runtimeInfo = runtimeInformationService.get()
 
         val message = TrackMessage.builder(event.name)

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/observability/probe/AutocompleteSuggestionAcceptedProbe.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/observability/probe/AutocompleteSuggestionAcceptedProbe.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.diagnostic.logger
 import com.mongodb.jbplugin.dialects.Dialect
+import com.mongodb.jbplugin.meta.injecting
 import com.mongodb.jbplugin.observability.TelemetryEvent
 import com.mongodb.jbplugin.observability.TelemetryService
 import com.mongodb.jbplugin.observability.useLogMessage
@@ -75,8 +76,7 @@ class AutocompleteSuggestionAcceptedProbe(
         val listCopy = events.toList()
         events.clear()
 
-        val application = ApplicationManager.getApplication()
-        val telemetry = application.getService(TelemetryService::class.java)
+        val telemetry by injecting<TelemetryService>()
 
         listCopy
             .groupingBy {

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/observability/probe/AutocompleteSuggestionAcceptedProbe.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/observability/probe/AutocompleteSuggestionAcceptedProbe.kt
@@ -6,7 +6,7 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.diagnostic.logger
 import com.mongodb.jbplugin.dialects.Dialect
-import com.mongodb.jbplugin.meta.injecting
+import com.mongodb.jbplugin.meta.service
 import com.mongodb.jbplugin.observability.TelemetryEvent
 import com.mongodb.jbplugin.observability.TelemetryService
 import com.mongodb.jbplugin.observability.useLogMessage
@@ -76,7 +76,7 @@ class AutocompleteSuggestionAcceptedProbe(
         val listCopy = events.toList()
         events.clear()
 
-        val telemetry by injecting<TelemetryService>()
+        val telemetry by service<TelemetryService>()
 
         listCopy
             .groupingBy {

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/observability/probe/ConnectionFailureProbe.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/observability/probe/ConnectionFailureProbe.kt
@@ -10,7 +10,7 @@ import com.intellij.openapi.project.Project
 import com.mongodb.jbplugin.accessadapter.datagrip.DataGripBasedReadModelProvider
 import com.mongodb.jbplugin.accessadapter.datagrip.adapter.isMongoDbDataSource
 import com.mongodb.jbplugin.accessadapter.slice.BuildInfo
-import com.mongodb.jbplugin.meta.injecting
+import com.mongodb.jbplugin.meta.service
 import com.mongodb.jbplugin.observability.TelemetryEvent
 import com.mongodb.jbplugin.observability.TelemetryService
 import com.mongodb.jbplugin.observability.useLogMessage
@@ -39,8 +39,8 @@ class ConnectionFailureProbe : DatabaseConnectionManager.Listener {
 
         val exception = if (th is SQLException) th.cause else th
 
-        val telemetryService by injecting<TelemetryService>()
-        val readModelProvider by project.injecting<DataGripBasedReadModelProvider>()
+        val telemetryService by service<TelemetryService>()
+        val readModelProvider by project.service<DataGripBasedReadModelProvider>()
 
         val dataSource = connectionPoint.dataSource
         val serverInfo = readModelProvider.slice(dataSource, BuildInfo.Slice)

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/observability/probe/ConnectionFailureProbe.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/observability/probe/ConnectionFailureProbe.kt
@@ -4,13 +4,13 @@ import com.intellij.database.dataSource.DatabaseConnection
 import com.intellij.database.dataSource.DatabaseConnectionManager
 import com.intellij.database.dataSource.DatabaseConnectionPoint
 import com.intellij.execution.rmi.RemoteObject
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.mongodb.jbplugin.accessadapter.datagrip.DataGripBasedReadModelProvider
 import com.mongodb.jbplugin.accessadapter.datagrip.adapter.isMongoDbDataSource
 import com.mongodb.jbplugin.accessadapter.slice.BuildInfo
+import com.mongodb.jbplugin.meta.injecting
 import com.mongodb.jbplugin.observability.TelemetryEvent
 import com.mongodb.jbplugin.observability.TelemetryService
 import com.mongodb.jbplugin.observability.useLogMessage
@@ -39,10 +39,9 @@ class ConnectionFailureProbe : DatabaseConnectionManager.Listener {
 
         val exception = if (th is SQLException) th.cause else th
 
-        val application = ApplicationManager.getApplication()
-        val telemetryService = application.getService(TelemetryService::class.java)
+        val telemetryService by injecting<TelemetryService>()
+        val readModelProvider by project.injecting<DataGripBasedReadModelProvider>()
 
-        val readModelProvider = project.getService(DataGripBasedReadModelProvider::class.java)
         val dataSource = connectionPoint.dataSource
         val serverInfo = readModelProvider.slice(dataSource, BuildInfo.Slice)
         val telemetryEvent =

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/observability/probe/NewConnectionActivatedProbe.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/observability/probe/NewConnectionActivatedProbe.kt
@@ -8,7 +8,7 @@ import com.intellij.openapi.diagnostic.logger
 import com.mongodb.jbplugin.accessadapter.datagrip.DataGripBasedReadModelProvider
 import com.mongodb.jbplugin.accessadapter.datagrip.adapter.isMongoDbDataSource
 import com.mongodb.jbplugin.accessadapter.slice.BuildInfo
-import com.mongodb.jbplugin.meta.injecting
+import com.mongodb.jbplugin.meta.service
 import com.mongodb.jbplugin.observability.TelemetryEvent
 import com.mongodb.jbplugin.observability.TelemetryService
 import com.mongodb.jbplugin.observability.useLogMessage
@@ -35,8 +35,8 @@ class NewConnectionActivatedProbe : DatabaseSessionStateListener {
     }
 
     override fun connected(session: DatabaseSession) {
-        val telemetryService by injecting<TelemetryService>()
-        val readModelProvider by session.project.injecting<DataGripBasedReadModelProvider>()
+        val telemetryService by service<TelemetryService>()
+        val readModelProvider by session.project.service<DataGripBasedReadModelProvider>()
         val dataSource = session.connectionPoint.dataSource
 
         if (!dataSource.isMongoDbDataSource()) {

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/observability/probe/NewConnectionActivatedProbe.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/observability/probe/NewConnectionActivatedProbe.kt
@@ -3,12 +3,12 @@ package com.mongodb.jbplugin.observability.probe
 import com.intellij.database.console.client.VisibleDatabaseSessionClient
 import com.intellij.database.console.session.DatabaseSession
 import com.intellij.database.console.session.DatabaseSessionStateListener
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.diagnostic.logger
 import com.mongodb.jbplugin.accessadapter.datagrip.DataGripBasedReadModelProvider
 import com.mongodb.jbplugin.accessadapter.datagrip.adapter.isMongoDbDataSource
 import com.mongodb.jbplugin.accessadapter.slice.BuildInfo
+import com.mongodb.jbplugin.meta.injecting
 import com.mongodb.jbplugin.observability.TelemetryEvent
 import com.mongodb.jbplugin.observability.TelemetryService
 import com.mongodb.jbplugin.observability.useLogMessage
@@ -35,12 +35,8 @@ class NewConnectionActivatedProbe : DatabaseSessionStateListener {
     }
 
     override fun connected(session: DatabaseSession) {
-        val application = ApplicationManager.getApplication()
-        val telemetryService = application.getService(TelemetryService::class.java)
-
-        val readModelProvider = session.project.getService(
-            DataGripBasedReadModelProvider::class.java
-        )
+        val telemetryService by injecting<TelemetryService>()
+        val readModelProvider by session.project.injecting<DataGripBasedReadModelProvider>()
         val dataSource = session.connectionPoint.dataSource
 
         if (!dataSource.isMongoDbDataSource()) {

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/observability/probe/PluginActivatedProbe.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/observability/probe/PluginActivatedProbe.kt
@@ -3,7 +3,7 @@ package com.mongodb.jbplugin.observability.probe
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.diagnostic.logger
-import com.mongodb.jbplugin.meta.injecting
+import com.mongodb.jbplugin.meta.service
 import com.mongodb.jbplugin.observability.TelemetryEvent
 import com.mongodb.jbplugin.observability.TelemetryService
 import com.mongodb.jbplugin.observability.useLogMessage
@@ -16,7 +16,7 @@ private val logger: Logger = logger<PluginActivatedProbe>()
 @Service
 class PluginActivatedProbe {
     fun pluginActivated() {
-        val telemetry by injecting<TelemetryService>()
+        val telemetry by service<TelemetryService>()
 
         telemetry.sendEvent(TelemetryEvent.PluginActivated)
 

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/observability/probe/PluginActivatedProbe.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/observability/probe/PluginActivatedProbe.kt
@@ -1,9 +1,9 @@
 package com.mongodb.jbplugin.observability.probe
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.diagnostic.logger
+import com.mongodb.jbplugin.meta.injecting
 import com.mongodb.jbplugin.observability.TelemetryEvent
 import com.mongodb.jbplugin.observability.TelemetryService
 import com.mongodb.jbplugin.observability.useLogMessage
@@ -16,8 +16,7 @@ private val logger: Logger = logger<PluginActivatedProbe>()
 @Service
 class PluginActivatedProbe {
     fun pluginActivated() {
-        val application = ApplicationManager.getApplication()
-        val telemetry = application.getService(TelemetryService::class.java)
+        val telemetry by injecting<TelemetryService>()
 
         telemetry.sendEvent(TelemetryEvent.PluginActivated)
 

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/settings/PluginSettings.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/settings/PluginSettings.kt
@@ -5,9 +5,11 @@
 
 package com.mongodb.jbplugin.settings
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.*
+import com.mongodb.jbplugin.meta.injecting
 import java.io.Serializable
+import kotlin.reflect.KMutableProperty0
+import kotlin.reflect.KProperty
 
 /**
  * The state component represents the persisting state. Don't use directly, this is only necessary
@@ -26,23 +28,46 @@ class PluginSettingsStateComponent : SimplePersistentStateComponent<PluginSettin
 
 /**
  * The settings themselves. They are tracked, so any change on the settings properties will be eventually
- * persisted by IntelliJ. To access the settings, use the useSettings provider.
+ * persisted by IntelliJ. To access the settings, use the pluginSetting provider. For example,
+ * let's say you want to get the isTelemetryEnabled setting, you would do:
  *
- * @see useSettings
+ * ```kt
+ * val isTelemetryEnabled by pluginSetting { ::isTelemetryEnabled }
+ * ```
+ *
+ * You'll see the settings as the underlying type (in this case, a boolean). If you want to modify
+ * the setting, specify a variable instead of a value:
+ *
+ * ```kt
+ * var isTelemetryEnabled by pluginSetting { ::isTelemetryEnabled }
+ * isTelemetryEnabled = false
+ * ```
+ *
+ * @see pluginSetting
  */
 class PluginSettings : BaseState(), Serializable {
     var isTelemetryEnabled by property(true)
     var hasTelemetryOptOutputNotificationBeenShown by property(false)
 }
 
-/**
- * Function that provides a reference to the current PluginSettings.
- *
- * @see PluginSettings
- *
- * @return
- */
-fun useSettings(): PluginSettings =
-    ApplicationManager.getApplication().getService(
-        PluginSettingsStateComponent::class.java,
-    ).state
+class SettingsDelegate<T>(private val settingProp: KMutableProperty0<T>) {
+    operator fun getValue(
+        thisRef: Any?,
+        property: KProperty<*>
+    ): T {
+        return settingProp.getter.call()
+    }
+
+    operator fun setValue(
+        thisRef: Any?,
+        property: KProperty<*>,
+        value: T
+    ) {
+        settingProp.setter.call(value)
+    }
+}
+
+fun <T> pluginSetting(cb: PluginSettings.() -> KMutableProperty0<T>): SettingsDelegate<T> {
+    val settings by injecting<PluginSettingsStateComponent>()
+    return SettingsDelegate(settings.state.cb())
+}

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/settings/PluginSettings.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/settings/PluginSettings.kt
@@ -6,7 +6,7 @@
 package com.mongodb.jbplugin.settings
 
 import com.intellij.openapi.components.*
-import com.mongodb.jbplugin.meta.injecting
+import com.mongodb.jbplugin.meta.service
 import java.io.Serializable
 import kotlin.reflect.KMutableProperty0
 import kotlin.reflect.KProperty
@@ -68,6 +68,6 @@ class SettingsDelegate<T>(private val settingProp: KMutableProperty0<T>) {
 }
 
 fun <T> pluginSetting(cb: PluginSettings.() -> KMutableProperty0<T>): SettingsDelegate<T> {
-    val settings by injecting<PluginSettingsStateComponent>()
+    val settings by service<PluginSettingsStateComponent>()
     return SettingsDelegate(settings.state.cb())
 }

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/settings/PluginSettingsConfigurable.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/settings/PluginSettingsConfigurable.kt
@@ -10,7 +10,7 @@ import com.intellij.ui.components.JBCheckBox
 import com.intellij.util.ui.FormBuilder
 import com.mongodb.jbplugin.i18n.SettingsMessages
 import com.mongodb.jbplugin.i18n.TelemetryMessages
-import com.mongodb.jbplugin.meta.injecting
+import com.mongodb.jbplugin.meta.service
 import javax.swing.JButton
 import javax.swing.JComponent
 import javax.swing.JPanel
@@ -28,20 +28,20 @@ class PluginSettingsConfigurable : Configurable {
     }
 
     override fun isModified(): Boolean {
-        val savedSettings by injecting<PluginSettingsStateComponent>()
+        val savedSettings by service<PluginSettingsStateComponent>()
         return settingsComponent.isTelemetryEnabledCheckBox.isSelected !=
             savedSettings.state.isTelemetryEnabled
     }
 
     override fun apply() {
-        val savedSettings by injecting<PluginSettingsStateComponent>()
+        val savedSettings by service<PluginSettingsStateComponent>()
         savedSettings.state.apply {
             isTelemetryEnabled = settingsComponent.isTelemetryEnabledCheckBox.isSelected
         }
     }
 
     override fun reset() {
-        val savedSettings by injecting<PluginSettingsStateComponent>()
+        val savedSettings by service<PluginSettingsStateComponent>()
         settingsComponent.isTelemetryEnabledCheckBox.isSelected =
             savedSettings.state.isTelemetryEnabled
     }

--- a/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/settings/PluginSettingsConfigurable.kt
+++ b/packages/jetbrains-plugin/src/main/kotlin/com/mongodb/jbplugin/settings/PluginSettingsConfigurable.kt
@@ -10,6 +10,7 @@ import com.intellij.ui.components.JBCheckBox
 import com.intellij.util.ui.FormBuilder
 import com.mongodb.jbplugin.i18n.SettingsMessages
 import com.mongodb.jbplugin.i18n.TelemetryMessages
+import com.mongodb.jbplugin.meta.injecting
 import javax.swing.JButton
 import javax.swing.JComponent
 import javax.swing.JPanel
@@ -27,21 +28,22 @@ class PluginSettingsConfigurable : Configurable {
     }
 
     override fun isModified(): Boolean {
-        val savedSettings = useSettings()
+        val savedSettings by injecting<PluginSettingsStateComponent>()
         return settingsComponent.isTelemetryEnabledCheckBox.isSelected !=
-            savedSettings.isTelemetryEnabled
+            savedSettings.state.isTelemetryEnabled
     }
 
     override fun apply() {
-        val savedSettings =
-            useSettings().apply {
-                isTelemetryEnabled = settingsComponent.isTelemetryEnabledCheckBox.isSelected
-            }
+        val savedSettings by injecting<PluginSettingsStateComponent>()
+        savedSettings.state.apply {
+            isTelemetryEnabled = settingsComponent.isTelemetryEnabledCheckBox.isSelected
+        }
     }
 
     override fun reset() {
-        val savedSettings = useSettings()
-        settingsComponent.isTelemetryEnabledCheckBox.isSelected = savedSettings.isTelemetryEnabled
+        val savedSettings by injecting<PluginSettingsStateComponent>()
+        settingsComponent.isTelemetryEnabledCheckBox.isSelected =
+            savedSettings.state.isTelemetryEnabled
     }
 
     override fun getDisplayName() = SettingsMessages.message("settings.display-name")

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/fixtures/IntegrationTestExtensions.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/fixtures/IntegrationTestExtensions.kt
@@ -23,12 +23,13 @@ import com.intellij.openapi.project.ProjectManager
 import com.intellij.testFramework.common.cleanApplicationState
 import com.intellij.testFramework.common.initTestApplication
 import com.intellij.testFramework.replaceService
+import com.mongodb.jbplugin.meta.injecting
 import com.mongodb.jbplugin.observability.LogMessage
 import com.mongodb.jbplugin.observability.LogMessageBuilder
 import com.mongodb.jbplugin.observability.RuntimeInformation
 import com.mongodb.jbplugin.observability.RuntimeInformationService
 import com.mongodb.jbplugin.settings.PluginSettings
-import com.mongodb.jbplugin.settings.useSettings
+import com.mongodb.jbplugin.settings.PluginSettingsStateComponent
 import kotlinx.coroutines.test.TestScope
 import org.junit.jupiter.api.extension.*
 import org.mockito.Mockito.mock
@@ -70,7 +71,8 @@ private class IntegrationTestExtension :
             )!!
         }
 
-        settings = useSettings()
+        val settingComponent by injecting<PluginSettingsStateComponent>()
+        settings = settingComponent.state
         settings.isTelemetryEnabled = true
         testScope = TestScope()
         project.withMockedService(application.getService(ClientSessionsManager::class.java))

--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/fixtures/IntegrationTestExtensions.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/fixtures/IntegrationTestExtensions.kt
@@ -23,7 +23,7 @@ import com.intellij.openapi.project.ProjectManager
 import com.intellij.testFramework.common.cleanApplicationState
 import com.intellij.testFramework.common.initTestApplication
 import com.intellij.testFramework.replaceService
-import com.mongodb.jbplugin.meta.injecting
+import com.mongodb.jbplugin.meta.service
 import com.mongodb.jbplugin.observability.LogMessage
 import com.mongodb.jbplugin.observability.LogMessageBuilder
 import com.mongodb.jbplugin.observability.RuntimeInformation
@@ -71,7 +71,7 @@ private class IntegrationTestExtension :
             )!!
         }
 
-        val settingComponent by injecting<PluginSettingsStateComponent>()
+        val settingComponent by service<PluginSettingsStateComponent>()
         settings = settingComponent.state
         settings.isTelemetryEnabled = true
         testScope = TestScope()


### PR DESCRIPTION
This PR plays a bit with Kotlin delegates to simplify dependency injection. I would like to have some more compile time checks to be fair, but this kind of works fine.

1. Implements a new delegate: `by service` that loads an application service. Can be used in two ways thanks to Kotlin type inference.

```kt
val telemetry: TelemetryService by service()
val telemetry by service<TelemetryService>()
```

2. Implements a new delegate: `by Project.service` that works the same way:

```kt
val project: Project
val myService by project.service<MyService>()
```

3. Implements granular setting access, to make it easier to work with settings.
```kt
val isTelemetryEnabled by pluginSetting { ::isTelemetryEnabled }
```

4. Implements also a `SharedFlow.latest` delegate that computes in background the property on each event received on the shared flow transparently for the user. This is useful to propagate UI changes:

```kt
class EventNumber(val number)
val sharedFlow: SharedFlow<EventNumber>

val latestNumber by sharedFlow.latest { number }
val doubleNumber by sharedFlow.latest { number * 2 }
```
```