### PR TITLE
fix: makes a List assignable to simple type INTELLIJ-120

### DIFF
--- a/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/observability/probe/NewConnectionActivatedProbeTest.kt
+++ b/packages/jetbrains-plugin/src/test/kotlin/com/mongodb/jbplugin/observability/probe/NewConnectionActivatedProbeTest.kt
@@ -83,7 +83,7 @@ internal class NewConnectionActivatedProbeTestForLocalEnvironment :
         isLocalhost = true,
         isEnterprise = false,
         isGenuine = true,
-        version = "7.0.14",
+        version = "7.0.15",
     )
 
 @RequiresMongoDbCluster(
@@ -97,5 +97,5 @@ internal class NewConnectionActivatedProbeTestForAtlasCliEnvironment :
         isLocalhost = true,
         isEnterprise = true,
         isGenuine = true,
-        version = "7.0.14",
+        version = "7.0.15",
     )

--- a/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/BsonType.kt
+++ b/packages/mongodb-mql-model/src/main/kotlin/com/mongodb/jbplugin/mql/BsonType.kt
@@ -175,7 +175,7 @@ data class BsonArray(
         is BsonAny -> true
         is BsonAnyOf -> otherType.types.any { this.isAssignableTo(it) }
         is BsonArray -> this.schema.isAssignableTo(otherType.schema)
-        else -> false
+        else -> this.schema.isAssignableTo(otherType)
     }
 }
 

--- a/packages/mongodb-mql-model/src/test/kotlin/com/mongodb/jbplugin/mql/BsonTypeTest.kt
+++ b/packages/mongodb-mql-model/src/test/kotlin/com/mongodb/jbplugin/mql/BsonTypeTest.kt
@@ -122,6 +122,10 @@ class BsonTypeTest {
                     // For queries written in Java, it is possible that the values are boxed which makes them nullable
                     // also. Such values should still be assignable to a detected non-nullable BsonType
                     arrayOf(BsonAnyOf(simpleType, BsonNull), simpleType, true),
+                    // A list of simple type is assignable to the simple type in case of filters like
+                    // $in. Example: { continent: { $in: ["Europe", "Asia"] } }
+                    arrayOf(BsonArray(simpleType), simpleType, true),
+                    arrayOf(BsonArray(BsonAnyOf(simpleType)), simpleType, true),
 
                     // Any other type is just not assignable to this BsonType
                     arrayOf(simpleTypes.randomOtherThan(simpleType), simpleType, false),
@@ -136,7 +140,6 @@ class BsonTypeTest {
                     arrayOf(BsonNull, simpleType, false),
 
                     // Collections as well are not assignable to these simple types
-                    arrayOf(BsonArray(simpleType), simpleType, false),
                     arrayOf(BsonObject(mapOf("simpleTypeField" to simpleType)), simpleType, false),
                 )
             }.toTypedArray()
@@ -154,6 +157,8 @@ class BsonTypeTest {
             // also. Such values should still be assignable to a detected non-nullable BsonType
             arrayOf(BsonAnyOf(BsonInt64, BsonNull), BsonInt64, true),
             arrayOf(BsonAnyOf(BsonInt32, BsonNull), BsonInt64, true),
+            // Possible when used in a $in Filter
+            arrayOf(BsonArray(BsonInt64), BsonInt64, true),
 
             // Any other type is just not assignable to this BsonType
             arrayOf(simpleTypes.randomOtherThan(setOf(BsonInt32, BsonInt64)), BsonInt64, false),
@@ -172,7 +177,6 @@ class BsonTypeTest {
             arrayOf(BsonNull, BsonInt64, false),
 
             // Collections as well are not assignable to these simple types
-            arrayOf(BsonArray(BsonInt64), BsonInt64, false),
             arrayOf(BsonObject(mapOf("simpleTypeField" to BsonInt64)), BsonInt64, false),
         )
 
@@ -188,6 +192,8 @@ class BsonTypeTest {
             // also. Such values should still be assignable to a detected non-nullable BsonType
             arrayOf(BsonAnyOf(BsonDecimal128, BsonNull), BsonDecimal128, true),
             arrayOf(BsonAnyOf(BsonDouble, BsonNull), BsonDecimal128, true),
+            // Possible when used in a $in Filter
+            arrayOf(BsonArray(BsonDecimal128), BsonDecimal128, true),
 
             // Any other type is just not assignable to this BsonType
             arrayOf(
@@ -210,7 +216,6 @@ class BsonTypeTest {
             arrayOf(BsonNull, BsonDecimal128, false),
 
             // Collections as well are not assignable to these simple types
-            arrayOf(BsonArray(BsonDecimal128), BsonDecimal128, false),
             arrayOf(BsonObject(mapOf("simpleTypeField" to BsonDecimal128)), BsonDecimal128, false),
         )
 
@@ -358,6 +363,15 @@ class BsonTypeTest {
                 arrayOf(BsonArray(BsonAnyOf(BsonString, BsonNull)), BsonArray(BsonString), true),
                 arrayOf(
                     BsonArray(BsonAnyOf(BsonString, BsonNull)),
+                    BsonArray(BsonAnyOf(BsonString, BsonNull)),
+                    true
+                ),
+                // This happens when the underlying field is array of simple type and we are querying
+                // for documents having just the mentioned value of mentioned type
+                // example: { list_of_amenities: "TV" }
+                arrayOf(BsonString, BsonArray(BsonString), true),
+                arrayOf(
+                    BsonAnyOf(BsonString, BsonNull),
                     BsonArray(BsonAnyOf(BsonString, BsonNull)),
                     true
                 ),


### PR DESCRIPTION
When using a $in filter, it is expected to provide a List of string/number, etc to be matched against a field which itself is a simple type (string/number, etc). This PR marks such assignment acceptable so that our linter does not throw false positive warnings.

<!--
  ^^^^^
  Please fill the title above according to https://www.conventionalcommits.org/en/v1.0.0/.

  type(scope): message <TICKET-NUMBER-IF-ANY>

  eg. fix(type-hint): infer type of a constant for type checking INTELLIJ-1111
-->

## Description

<!--- Describe your changes in detail so reviewers have enough content on what this PR aims to achieve -->
<!--- If applicable, describe (or illustrate) architecture flow -->

### Checklist

- [ ] New tests and/or benchmarks are included.
- [ ] Documentation is changed or added.
- [ ] Changelog is updated accordingly.
- [ ] I have signed the MongoDB Contributor License Agreement (https://www.mongodb.com/legal/contributor-agreement).

## Open Questions

<!--- Any particular areas you'd like reviewers to pay attention to? -->